### PR TITLE
Allow one-liner match statements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLStyle"
 uuid = "d8e11817-5142-5d16-987a-aa16d5891078"
 authors = ["thautwarm <twshere@outlook.com>"]
-version = "0.4.0"
+version = "0.4.1"
 
 [extras]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/docs/syntax/pattern.md
+++ b/docs/syntax/pattern.md
@@ -1,7 +1,23 @@
 Patterns
 =======================
 
-Patterns provide convenient ways to manipulate data.
+Patterns provide convenient ways to manipulate data. The basic syntax for pattern matching with MLStyle is of the form
+```julia
+@match data begin
+    pattern1 => result1
+    pattern2 => result2
+    ...
+    patternn => resultn
+end
+```
+MLStyle will first test if `data` is matched by `pattern1` and if it does match, return `result1`. If `pattern1` does not match, then MLStyle moves on to the next pattern. If no pattern in the list matches `data`, an error is thrown.
+
+In version 0.4.1 and newer, if you only have a single pattern you may instead write
+```julia
+@match data pattern => result
+```
+without the block syntax.
+
 
 Literal Patterns
 ------------------------

--- a/src/MatchImpl.jl
+++ b/src/MatchImpl.jl
@@ -458,7 +458,7 @@ end
 @specialize
 
 function gen_match(val, tbl, __source__::LineNumberNode, __module__::Module)
-    Meta.isexpr(tbl, :block) || tbl = Expr(:block, tbl)
+    Meta.isexpr(tbl, :block) || (tbl = Expr(:block, tbl))
     branches = Pair{Function,Tuple{LineNumberNode,Int}}[]
     k = 0
     ln = __source__

--- a/src/MatchImpl.jl
+++ b/src/MatchImpl.jl
@@ -458,7 +458,7 @@ end
 @specialize
 
 function gen_match(val, tbl, __source__::LineNumberNode, __module__::Module)
-    @assert Meta.isexpr(tbl, :block)
+    Meta.isexpr(tbl, :block) || tbl = Expr(:block, tbl)
     branches = Pair{Function,Tuple{LineNumberNode,Int}}[]
     k = 0
     ln = __source__

--- a/test/match.jl
+++ b/test/match.jl
@@ -123,4 +123,8 @@
         @test ast_match(:x)       === nothing
     end
 
+    @testset "one-liner match" begin
+        @test (@match 1 1 => 2) == 2
+        @test (@match [1, 2, 3] [hd, tl...] => (hd, tl)) == (1, [2,3])
+    end
 end


### PR DESCRIPTION
Closes #93.

```julia
julia> using MLStyle

julia> @match 1 x => x + 1
2
```
I also updated the docs on pattern matching to include a note about the strucutre of `@match` and this syntax.