### PR TITLE
avoid "type DataType has no field size"

### DIFF
--- a/src/AbstractPatterns/impl/RedyFlavoured.jl
+++ b/src/AbstractPatterns/impl/RedyFlavoured.jl
@@ -221,7 +221,7 @@ function myimpl()
         if v isa Symbol
             v = QuoteNode(v)
         end
-        (isprimitivetype(ty) || ty.size == 0 && !ismutabletype(ty)) ?
+        (isprimitivetype(ty) || !ismutabletype(ty) && Core.sizeof(ty) == 0) ?
         CheckCond(:($(target.repr) === $v)) : CheckCond(:($(target.repr) == $v))
     end
 


### PR DESCRIPTION
This tries to avoid the issue described #147 that breaks this package on julia 1.9-DEV.

The julia change that triggers this is https://github.com/JuliaLang/julia/pull/47170.
Looking at the changes in that PR I first tried to simply replace `ty.size` with `Core.sizeof(ty)`, but that gave an error: "Type Symbol does not have a definite size."

Since

```julia
julia> isprimitivetype(Symbol)
false

julia> ismutabletype(Symbol)
true
```

I figured we could just use the short circuiting to avoid calling sizeof for Symbol by switching the order of the &&.

```julia
julia> (false || !true && error())
false
```

There may be a better way to fix this however.