### PR TITLE
better error message for empty expression

### DIFF
--- a/src/AbstractPatterns/impl/RedyFlavoured.jl
+++ b/src/AbstractPatterns/impl/RedyFlavoured.jl
@@ -221,7 +221,7 @@ function myimpl()
         if v isa Symbol
             v = QuoteNode(v)
         end
-        (isprimitivetype(ty) || ty.size == 0 && !ismutabletype(ty)) ?
+        (isprimitivetype(ty) || sizeof(ty) == 0 && !ismutabletype(ty)) ?
         CheckCond(:($(target.repr) === $v)) : CheckCond(:($(target.repr) == $v))
     end
 

--- a/src/MatchImpl.jl
+++ b/src/MatchImpl.jl
@@ -453,7 +453,10 @@ function gen_switch(val, ex, __source__::LineNumberNode, __module__::Module)
             is_ln && (ln = stmt)
         end
     end
-
+    isempty(branches) && return Expr(:block,
+        __source__,
+        :(throw(ArgumentError("empty match expression")))
+    )
     backend(val, branches, terminal, __source__; hygienic = false)
 end
 
@@ -639,6 +642,10 @@ function gen_match(val, tbl, __source__::LineNumberNode, __module__::Module)
         end
     end
 
+    isempty(branches) && return Expr(:block,
+        __source__,
+        :(throw(ArgumentError("empty match expression")))
+    )
     backend(val, branches, terminal, __source__; hygienic = true)
 end
 

--- a/test/match.jl
+++ b/test/match.jl
@@ -135,3 +135,6 @@
         @test val === nothing
     end
 end
+
+@test_macro_throws ArgumentError @match 1 begin
+end

--- a/test/switch.jl
+++ b/test/switch.jl
@@ -47,3 +47,6 @@
     # Non-exhaustive matches fail silently.
     try_setflag_2("")
 end
+
+@test_macro_throws ArgumentError @switch 1 begin
+end


### PR DESCRIPTION
```julia
julia> using MLStyle

julia> @match 1 begin
       end
ERROR: ArgumentError: empty match expression
Stacktrace:
 [1] top-level scope
   @ REPL[2]:1
```