### PR TITLE
Demonstrate `@switch` with multiline block

### DIFF
--- a/docs/syntax/switch.md
+++ b/docs/syntax/switch.md
@@ -28,12 +28,16 @@ julia> x = (33, 44)
 (33, 44)
 
 julia> @switch x begin
-           @case (a::Float64, _)
-               print(a)
+           @case (var::Float64, _)
+               print(var)
                println(" float")
-           @case (a::Int64, _)
-               print(a)
+           @case (var::Int64, _)
+               print(var)
                println(" int")
         end
 33 int
+
+julia> var
+33
 ```
+

--- a/docs/syntax/switch.md
+++ b/docs/syntax/switch.md
@@ -28,17 +28,12 @@ julia> x = (33, 44)
 (33, 44)
 
 julia> @switch x begin
-       @case (var, _)
-           println(var)
-       end
-33
-
-julia> var
-33
-
-julia> @switch 1 begin
-       @case (var, _)
-           println(var)
-       end
-ERROR: matching non-exhaustive, at #= REPL[25]:1 =#
+           @case (a::Float64, _)
+               print(a)
+               println(" float")
+           @case (a::Int64, _)
+               print(a)
+               println(" int")
+        end
+33 int
 ```


### PR DESCRIPTION
Closes https://github.com/thautwarm/MLStyle.jl/issues/178 

I guess the point of `@switch` is to make the RHS shorter when it has multiple statements.