### PR TITLE
Update CI configuration

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,7 +4,7 @@ on:
   - pull_request
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -17,32 +17,15 @@ jobs:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
-        arch:
-          - x86
-          - x64
-        exclude:
-          # 32-bit Julia binaries are not available on macOS
-          - os: macOS-latest
-            arch: x86
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v5
         with:
-          file: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
- don't force an arch for Julia to use: e.g. macOS runners are on
  ARM these days, and for a package like this, there seems little to no
  benefit to test on a 32bit system
- update various actions to latest, supported version
- use julia-actions/cache for more reliable caching
- update codecov-action to current version

Warning: for code coverage to work, you'll have to configure a CODECOV_TOKEN
on your repository; or else configure the repository for "tokenless" upload.
Details are explained on <https://docs.codecov.com/docs/codecov-tokens>.
